### PR TITLE
Derive boot drive index from OS root string

### DIFF
--- a/import2vbox.pl
+++ b/import2vbox.pl
@@ -177,6 +177,9 @@ if (@roots > 1) {
 }
 my $root = $roots[0];
 
+# Derive boot drive index from root string (format is always '/dev/sdX#' according to docs)
+my $boot_drive_index = ord(substr($root, 7, 1)) - ord('a');
+
 # Save the inspection data.
 my $type = $g->inspect_get_type ($root); #linux
 my $distro = $g->inspect_get_distro ($root); #debian
@@ -453,7 +456,7 @@ for ($i = 0; $i < @converted_disks; ++$i)
     my $href = $converted_disks[$i];
 
     my $boot_drive;
-    if ($i == 0) {
+    if ($i == $boot_drive_index) {
         $boot_drive = "True";
     } else {
         $boot_drive = "False";


### PR DESCRIPTION
import2vbox currently always marks the first disk as boot disk regardless of which drive actually contained the OS due to a hard coded comparison "== 0".

This MR changes that as it derives the boot disk index from the root drive the OS was detected on. This produces an ovf with the correct disk marked as boot device. Sadly this doesn't make a difference in VirtualBox atm as VirtualBox doesn't seem to support the boot flag in the ovf file-format.

Related VirtualBox issue: https://www.virtualbox.org/ticket/6979